### PR TITLE
added future package to solve compatibility with python3 (reprlib)

### DIFF
--- a/flask_trace/__init__.py
+++ b/flask_trace/__init__.py
@@ -4,11 +4,10 @@ from __future__ import absolute_import
 from functools import wraps
 import inspect
 import logging
-import repr as reprlib
+import reprlib
 import sys
 import uuid
 
-__version__ = '0.0.3'
 __all__ = ('get_log_id', 'trace', 'Formatter')
 
 

--- a/flask_trace/__init__.py
+++ b/flask_trace/__init__.py
@@ -1,13 +1,18 @@
 # coding: utf-8
-
 from __future__ import absolute_import
+
+try:
+    import reprlib  # Python 3
+except ImportError:
+    import repr as reprlib  # Python2
+
 from functools import wraps
 import inspect
 import logging
-import reprlib
 import sys
 import uuid
 
+__version__ = '0.0.4'
 __all__ = ('get_log_id', 'trace', 'Formatter')
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ from setuptools import setup
 import codecs
 import os
 
+import flask_trace
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the relevant file
@@ -10,7 +12,7 @@ with codecs.open('README.rst', encoding='utf-8') as f:
 
 setup(
     name="flask_trace",
-    version="0.0.4",
+    version=flask_trace.__version__,
 
     description="Log trace decorator function for Flask",
     long_description=long_description,
@@ -41,6 +43,5 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     keywords='flask log trace logging',
-    install_requires=['future'],
     packages=['flask_trace'],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ from setuptools import setup
 import codecs
 import os
 
-import flask_trace
-
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the relevant file
@@ -12,7 +10,7 @@ with codecs.open('README.rst', encoding='utf-8') as f:
 
 setup(
     name="flask_trace",
-    version=flask_trace.__version__,
+    version="0.0.4",
 
     description="Log trace decorator function for Flask",
     long_description=long_description,
@@ -43,5 +41,6 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     keywords='flask log trace logging',
+    install_requires=['future'],
     packages=['flask_trace'],
 )


### PR DESCRIPTION
The repr module has been renamed to reprlib in Python 3(https://docs.python.org/2/library/repr.html). Thia PR solves the problem using 'future' package (https://github.com/PythonCharmers/python-future).
